### PR TITLE
Minor capitalization correction for GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ port forwarding without your help, just like a regular SSH client would:
 
 Teleconsole is built on top of [Gravitational Teleport](http://gravitational.com/teleport) 
 which is a clustered SSH server with built-in SSH bastion/proxy. Both projects are 
-open source and hosted [here on Github](https://github.com/gravitational/teleport/blob/master/README.md).
+open source and hosted [here on GitHub](https://github.com/gravitational/teleport/blob/master/README.md).
 
 What happens when you type `teleconsole`?
 


### PR DESCRIPTION
GitHub uses a capital 'H' 🤓
https://github.com
![](https://cloud.githubusercontent.com/assets/49038/26196161/fa47fb1a-3bb5-11e7-978f-29c4af682648.png)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
