### PR TITLE
-i to use public key instead of private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,19 +189,31 @@ For more info, drop us an email: [info@gravitational.com](mailto:info@gravitatio
 
 ## Building from source
 
-To build the binaries
-1. Clone this repository: `git clone https://github.com/gravitational/teleconsole`
-2. Install golang >= 1.7: `sudo apt install golang-1.9`
+Instructions below are for Ubuntu 17.04
+
+Pre-requisites
+
+1. Install golang >= 1.7: `sudo apt install golang-1.9`
 - required for `context` (https://stackoverflow.com/a/42802790/4126114)
 2. Verify version: `go version` (e.g. `go version go1.9.2 linux/amd64`)
-2. Set `GOPATH`: `export GOPATH=$PWD`
-3. Install dependencies: `go get -v ./...`
-5. Build binaries: `make`
+3. Set `GOPATH`: `export GOPATH=$HOME/go`
+
+
+To build the binaries
+
+1. Clone this repository: `go get github.com/gravitational/teleconsole`
+2. `cd $GOPATH/src/github.com/gravitational/teleconsole`
+3. Install dependencies: `go get ./...` (add `-v` for higher verbosity)
+4. Build binaries: `make`
+
 
 To run tests
-3. Install test dependencies: `get get -v -t ./...`
-4. Run tests: `make test`
+
+1. Install test dependencies: `get -t ./...`
+2. Run tests: `make test`
+
 
 To make a release
+
 - `make release`
 - check `Makefile` for more details

--- a/README.md
+++ b/README.md
@@ -186,3 +186,14 @@ component of our commercial offering for deploying and remotely [operating SaaS 
 3rd party enterprise infrastructure](https://gravitational.com/product). 
 
 For more info, drop us an email: [info@gravitational.com](mailto:info@gravitational.com)
+
+## Building from source
+
+1. Clone this repository: `git clone https://github.com/gravitational/teleconsole`
+2. Install dependencies: `GOPATH=$PWD go get -v ./...`
+3. Run tests: `GOPATH=$PWD make test`
+4. Build binaries: `GOPATH=$PWD make`
+
+To make a release
+- `GOPATH=$PWD make release`
+- check `Makefile` for more details

--- a/README.md
+++ b/README.md
@@ -189,11 +189,19 @@ For more info, drop us an email: [info@gravitational.com](mailto:info@gravitatio
 
 ## Building from source
 
+To build the binaries
 1. Clone this repository: `git clone https://github.com/gravitational/teleconsole`
-2. Install dependencies: `GOPATH=$PWD go get -v ./...`
-3. Run tests: `GOPATH=$PWD make test`
-4. Build binaries: `GOPATH=$PWD make`
+2. Install golang >= 1.7: `sudo apt install golang-1.9`
+- required for `context` (https://stackoverflow.com/a/42802790/4126114)
+2. Verify version: `go version` (e.g. `go version go1.9.2 linux/amd64`)
+2. Set `GOPATH`: `export GOPATH=$PWD`
+3. Install dependencies: `go get -v ./...`
+5. Build binaries: `make`
+
+To run tests
+3. Install test dependencies: `get get -v -t ./...`
+4. Run tests: `make test`
 
 To make a release
-- `GOPATH=$PWD make release`
+- `make release`
 - check `Makefile` for more details

--- a/lib/identity.go
+++ b/lib/identity.go
@@ -1,9 +1,6 @@
 package lib
 
 import (
-	"crypto/dsa"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -178,11 +175,11 @@ func loginFromFile(fp string) (*sshLogin, error) {
 	pubKey, err := ssh.ParsePublicKey(bytes)
 	if err != nil {
 
-    // check if this was a private key and alert accordingly:
-    p, err := ssh.ParseRawPrivateKey(bytes)
-    if err == nil {
-      return nil, trace.Wrap("Private keys are no longer supported. Check https://github.com/gravitational/teleconsole/issues/19 for more details")
-    }
+		// check if this was a private key and alert accordingly:
+		_, err := ssh.ParseRawPrivateKey(bytes)
+		if err == nil {
+			return nil, trace.Wrap(err, "Private keys are no longer supported. Check https://github.com/gravitational/teleconsole/issues/19 for more details")
+		}
 
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Hello. I wrote up some code to fix #19.

It deprecates using private keys in favor of using public keys.

The problem is that I could neither install the project dependencies, nor build it, nor run the tests.
I'm not sure if it's just something that I'm screwing up as I'm a golang newbie or something else.

I also tried adding some instructions in the readme about how to "build from source".

It would probably be a good idea to install dependencies via godep (example [reference](https://devcenter.heroku.com/articles/go-dependencies-via-godep))

Edit 1: related to build fail: Issue #32 and #16 

Edit 2: related issue to #19 is #9 